### PR TITLE
Add git repository to meta

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -20,4 +20,9 @@ WriteMakefile(
         'Test::More'    => '0',
         'Text::Diff'    => '0'
     },
+    META_MERGE => {
+        resources => {
+	    repository  => 'git://github.com/larryl/Test-PerlTidy.git',
+        },
+    },
 );


### PR DESCRIPTION
This adds the repository git URL for this project to the distribution metadata, which will add the link from the dist page in metacpan and make it easier for potential contributors to find this git repository.