### PR TITLE
Remove taint mode from critic test.

### DIFF
--- a/lib/Test/PerlTidy.pm
+++ b/lib/Test/PerlTidy.pm
@@ -175,6 +175,8 @@ sub load_file {
 
 __END__
 
+=for stopwords Hmmm perltidy cvs perltidyrc subdirectories listref canonified pre von der Leszczynski perl
+
 =head1 NAME
 
 Test::PerlTidy - check that all your files are tidy.

--- a/t/critic.t
+++ b/t/critic.t
@@ -1,4 +1,4 @@
-#!perl -T
+#!perl
 
 use strict;
 use warnings;


### PR DESCRIPTION
I am not sure what the -T should be necessary for this test, and I get this
error with it:

```
t/critic.t ............ Insecure dependency in chdir while running with -T switch at /home/ollisg/perl5/perlbrew/perls/perl-5.29.3/lib/5.29.3/File/Find.pm line 375.
t/critic.t ............ Dubious, test returned 2 (wstat 512, 0x200)
```

While I was in here, I also added stopwords to the POD which was preventing the test from passing.

```
#   Failed test 'Test::Perl::Critic for "lib/Test/PerlTidy.pm"'
#   at /home/ollisg/.perlbrew/libs/perl-5.29.3@dev/lib/perl5/Test/Perl/Critic.pm line 121.
# 
#   Check the spelling in your POD: Hmmm perltidy cvs perltidyrc subdirectories listref canonified pre von der Leszczynski perl at line 1, near 'package Test::PerlTidy;'.
#   Documentation::PodSpelling (Severity: 1)
#     Did you write the documentation? Check.
```