### PR TITLE
Migrate to Path::Tiny instead of File::Slurp

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -11,7 +11,7 @@ WriteMakefile(
     PREREQ_PM    => {
         'Carp'          => '0',
         'File::Finder'  => '0',
-        'File::Slurp'   => '0',
+        'Path::Tiny'    => '0',
         'File::Spec'    => '0',
         'IO::File'      => '0',
         'parent'        => '0',

--- a/lib/Test/PerlTidy.pm
+++ b/lib/Test/PerlTidy.pm
@@ -2,6 +2,7 @@ package Test::PerlTidy;
 
 use strict;
 use warnings;
+use English qw( -no_match_vars );
 
 use parent 'Exporter';
 
@@ -10,7 +11,7 @@ use vars qw( @EXPORT );    ## no critic (Modules::ProhibitAutomaticExportation)
 
 use Carp;
 use File::Finder;
-use File::Slurp;
+use Path::Tiny qw( path );
 use File::Spec;
 use IO::File;
 use Perl::Tidy;
@@ -67,7 +68,11 @@ sub is_file_tidy {
 
     # If there were perltidy errors report them and return.
     $stderr_fh->seek( 0, 0 );
-    my $stderr = read_file($stderr_fh);
+    binmode $stderr_fh, ':encoding(UTF-8)' or croak "error setting binmode $!";
+    my $stderr = do {
+        local $INPUT_RECORD_SEPARATOR = undef;
+        <$stderr_fh>;
+    };
     if ($stderr) {
         unless ($MUTE) {
             $test->diag("perltidy reported the following errors:\n");
@@ -167,7 +172,7 @@ sub load_file {
     return unless -f $filename;
 
     # Slurp the file.
-    my $content = read_file($filename);
+    my $content = path($filename)->slurp_utf8;
     return $content;
 }
 


### PR DESCRIPTION
This uses `Path::Tiny` instead of `File::Slurp`.  It fixes the rt127449.  https://rt.cpan.org/Ticket/Display.html?id=127449 . `File::Slurp` has some problems as discussed here: http://blogs.perl.org/users/leon_timmermans/2015/08/fileslurp-is-broken-and-wrong.html

Though I did make an attempt to get `File::Slurp` to use the correct encodings with this patch:

```diff
diff --git a/lib/Test/PerlTidy.pm b/lib/Test/PerlTidy.pm
index 1fd7616..75fdb1a 100644
--- a/lib/Test/PerlTidy.pm
+++ b/lib/Test/PerlTidy.pm
@@ -67,7 +67,7 @@ sub is_file_tidy {
 
     # If there were perltidy errors report them and return.
     $stderr_fh->seek( 0, 0 );
-    my $stderr = read_file($stderr_fh);
+    my $stderr = read_file( $stderr_fh, { binmode => ':utf8' } );
     if ($stderr) {
         unless ($MUTE) {
             $test->diag("perltidy reported the following errors:\n");
@@ -167,7 +167,7 @@ sub load_file {
     return unless -f $filename;
 
     # Slurp the file.
-    my $content = read_file($filename);
+    my $content = read_file( $filename, { binmode => ':utf8' } );
     return $content;
 }
 
```

it works, but it gives some pretty annoying warnings:

```
# The file 't/not_tidy.t' is not tidy
# +--+----------------------------------+-----------------------------------+
# | 1|use utf8;                         |use utf8;                          |
# * 2|use  strict;  # \x{706b}\x{96de}  |use strict;    # \x{706b}\x{96de}  *
# | 3|use warnings;                     |use warnings;                      |
# | 4|use Test::More;                   |use Test::More;                    |
# | 5|                                  |                                   |
# +--+----------------------------------+-----------------------------------+

#   Failed test ''t/not_tidy.t''
#   at t/exclude_perltidy.t line 11.
sysread() is deprecated on :utf8 handles. This will be a fatal error in Perl 5.30 at /home/ollisg/.perlbrew/libs/perl-5.29.3@dev/lib/perl5/File/Slurp.pm line 179.
sysread() is deprecated on :utf8 handles. This will be a fatal error in Perl 5.30 at /home/ollisg/.perlbrew/libs/perl-5.29.3@dev/lib/perl5/File/Slurp.pm line 179.
sysread() is deprecated on :utf8 handles. This will be a fatal error in Perl 5.30 at /home/ollisg/.perlbrew/libs/perl-5.29.3@dev/lib/perl5/File/Slurp.pm line 179.
sysread() is deprecated on :utf8 handles. This will be a fatal error in Perl 5.30 at /home/ollisg/.perlbrew/libs/perl-5.29.3@dev/lib/perl5/File/Slurp.pm line 179.
t/exclude_perltidy.t .. 12/12 # Looks like you failed 1 test of 12.
```